### PR TITLE
Fix cache headers vulnerability to prevent sensitive pages from being cached

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/MvcConfiguration.java
+++ b/src/main/java/org/owasp/webgoat/container/MvcConfiguration.java
@@ -261,10 +261,12 @@ class CacheControlHeadersInterceptor implements HandlerInterceptor {
     
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        // Set cache control headers for all requests
-        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+        // Set strict cache control headers for all requests to prevent any caching of sensitive pages
+        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, private");
         response.setHeader("Pragma", "no-cache");
         response.setHeader("Expires", "0");
+        // Add X-Content-Type-Options header to prevent MIME type sniffing
+        response.setHeader("X-Content-Type-Options", "nosniff");
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced the Cache-Control header by adding the 'private' directive to prevent sensitive pages from being cached
- Added X-Content-Type-Options: nosniff header to prevent MIME type sniffing attacks

## Test plan
- Verify all pages have the updated cache control headers by checking network responses
- Confirm that sensitive pages are not cached by the browser