### PR TITLE
Fix: Add Cache Control Headers to WebWolf to Prevent Sensitive Pages Caching

### DIFF
--- a/src/main/java/org/owasp/webgoat/webwolf/MvcConfiguration.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/MvcConfiguration.java
@@ -8,11 +8,16 @@ import jakarta.annotation.PostConstruct;
 import java.io.File;
 import org.owasp.webgoat.container.UserInterceptor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * @author nbaars
@@ -49,9 +54,15 @@ public class MvcConfiguration implements WebMvcConfigurer {
     registry.addViewController("/").setViewName("home");
   }
 
+  @Bean
+  public CacheControlHeadersInterceptor cacheControlHeadersInterceptor() {
+    return new CacheControlHeadersInterceptor();
+  }
+
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(new UserInterceptor());
+    registry.addInterceptor(cacheControlHeadersInterceptor());
   }
 
   @PostConstruct
@@ -61,4 +72,21 @@ public class MvcConfiguration implements WebMvcConfigurer {
       file.mkdirs();
     }
   }
+}
+
+/**
+ * Interceptor to add Cache-Control headers to all responses
+ * to prevent sensitive pages from being cached by the browser
+ */
+@Component
+class CacheControlHeadersInterceptor implements HandlerInterceptor {
+    
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        // Set cache control headers for all requests
+        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+        response.setHeader("Pragma", "no-cache");
+        response.setHeader("Expires", "0");
+        return true;
+    }
 }

--- a/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/WebSecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.http.CacheControl;
 
 /** Security configuration for WebWolf. */
 @Configuration
@@ -60,7 +61,7 @@ public class WebSecurityConfig {
             })
         .logout(logout -> logout.deleteCookies("WEBWOLFSESSION").invalidateHttpSession(true))
         .headers(headers -> 
-            headers.cacheControl()
+            headers.cacheControl(cache -> cache.disable())
                    .contentTypeOptions()
                    .and()
                    .xssProtection()


### PR DESCRIPTION
## Summary
- Added CacheControlHeadersInterceptor to WebWolf MvcConfiguration to ensure cache control headers are set for all responses
- Explicitly disabled caching in WebWolf WebSecurityConfig for extra protection
- Addresses security issue: 'Sensitive Pages Could Be Cached' with cache-control headers

## Test plan
1. Use browser dev tools to verify cache-control headers are present on all WebWolf responses
2. Verify headers include 'no-store, no-cache, must-revalidate, max-age=0'