### PR TITLE
Fix Sensitive Pages Caching Vulnerability

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
+++ b/src/main/java/org/owasp/webgoat/container/WebSecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.CacheControlHeadersWriter;
 import org.springframework.http.CacheControl;
 
 /** Security configuration for WebGoat. */
@@ -61,7 +62,10 @@ public class WebSecurityConfig {
         .logout(logout -> logout.deleteCookies("JSESSIONID").invalidateHttpSession(true))
         .csrf(csrf -> csrf.disable())
         .headers(headers -> 
-            headers.cacheControl(cache -> cache.disable())
+            headers.cacheControl(cache -> cache.mustRevalidate()
+                                             .noStore()
+                                             .noCache()
+                                             .maxAge(0))
                    .contentTypeOptions()
                    .and()
                    .xssProtection()


### PR DESCRIPTION
## Summary
- Fixed the 'Sensitive Pages Could Be Cached' vulnerability by implementing proper cache control headers
- Added appropriate cache control headers with no-store, no-cache, mustRevalidate, and maxAge(0) directives
- This addresses the issue with XXE.lesson.lesson endpoint that was vulnerable to caching sensitive content

## Test plan
- Verify HTTP response headers on XXE.lesson.lesson to include Cache-Control: no-cache, no-store, must-revalidate, max-age=0
- Confirm that browsers do not cache sensitive pages by checking the Network tab in browser developer tools