### PR TITLE
Fix sensitive pages caching vulnerability

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/MvcConfiguration.java
+++ b/src/main/java/org/owasp/webgoat/container/MvcConfiguration.java
@@ -261,10 +261,12 @@ class CacheControlHeadersInterceptor implements HandlerInterceptor {
     
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        // Set cache control headers for all requests
-        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+        // Set stronger cache control headers for all requests
+        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, private");
         response.setHeader("Pragma", "no-cache");
         response.setHeader("Expires", "0");
+        // Prevent browsers from storing the page in history cache
+        response.setHeader("X-Content-Type-Options", "nosniff");
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced cache control headers to prevent sensitive pages from being cached
- Added 'private' directive to Cache-Control header to prevent shared caches from storing responses
- Added X-Content-Type-Options: nosniff header for better security

## Test plan
- Verify that sensitive pages return proper cache control headers
- Test with browser developer tools to ensure pages aren't cached